### PR TITLE
[Feat/#14] - RefreshToken 기능 구현

### DIFF
--- a/SossBar/src/main/java/com/sossbar/global/common/code/ErrorCode.java
+++ b/SossBar/src/main/java/com/sossbar/global/common/code/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     KAKAO_USER_INFO_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회 실패", "AUTH-004"),
     KAKAO_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "카카오 계정에 이메일이 없습니다.", "AUTH-005"),
     KAKAO_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "카카오 로그인에 실패했습니다.", "AUTH-006"),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다.", "AUTH-007"),
 
     // IMAGE FILE
     FILE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "파일이 없습니다.", "FILE-001"),

--- a/SossBar/src/main/java/com/sossbar/global/config/SecurityConfig.java
+++ b/SossBar/src/main/java/com/sossbar/global/config/SecurityConfig.java
@@ -12,6 +12,13 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
@@ -26,6 +33,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
                 .addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // 세션 정책을 stateless로 설정 -> 서버가 세션을 생성하지 않고 토큰 기반 인증을 사용하도록 설정 = jwt 방식
@@ -40,5 +48,19 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() { // 패스워드 암호화
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    // TODO: 쿠키 테스트를 위해 추가함, 추후 배포시 cors 관련 코드 삭제
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/SossBar/src/main/java/com/sossbar/oauth2/jwt/JwtAuthorizationFilter.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/jwt/JwtAuthorizationFilter.java
@@ -1,9 +1,11 @@
 package com.sossbar.oauth2.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sossbar.global.common.code.ErrorCode;
+import com.sossbar.global.common.exception.BusinessException;
+import com.sossbar.global.common.template.ApiResTemplate;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +13,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import org.springframework.web.filter.GenericFilterBean;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -25,15 +26,42 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     // 모든 요청이 들어올 때 필터가 가로채 인증 로직 실행
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String uri = request.getRequestURI();
 
-        String token = resolveToken(request);
+        try {
+            if (uri.equals("/api/v1/login/reissue")) {
+                filterChain.doFilter(request, response);
+                return;
+            }
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            String token = resolveToken(request);
+
+            // TODO: 회원 탈퇴시 토큰 사용 불가능 하게 예외 설정
+            if (token != null) {
+                if (jwtTokenProvider.validateToken(token)) {
+                    Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } else {
+                    setErrorResponse(response, ErrorCode.JWT_INVALID);
+                    return;
+                }
+            }
+
+            filterChain.doFilter(request, response);
+
+        } catch (BusinessException ex) {
+            setErrorResponse(response, ex.getErrorCode());
         }
+    }
 
-        filterChain.doFilter(request, response);
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatusCode());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResTemplate<?> body = ApiResTemplate.errorResponse(errorCode, errorCode.getMessage());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 
     // 요청에서 토큰 추출 메소드

--- a/SossBar/src/main/java/com/sossbar/oauth2/jwt/JwtTokenProvider.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/jwt/JwtTokenProvider.java
@@ -30,10 +30,13 @@ public class JwtTokenProvider {
     private final UserRepository userRepository;
 
     @Value("${jwt.expire-time}")
-    private String tokenExpireTime;
+    private String accesstokenExpireTime;
 
     @Value("${jwt.secret}")
     private String secret;
+
+    @Value("${refresh-token.expire.time}")
+    private String refreshTokenExpireTime;
 
     private SecretKey key;
 
@@ -50,7 +53,7 @@ public class JwtTokenProvider {
     // 토큰 생성
     public String generateToken(User user) {
         Date now = new Date();
-        Date expireDate = new Date(now.getTime() + Long.parseLong(tokenExpireTime));
+        Date expireDate = new Date(now.getTime() + Long.parseLong(accesstokenExpireTime));
 
         return Jwts.builder()
                 .subject(user.getId().toString())   // 토큰 주체를 id로 설정
@@ -109,5 +112,24 @@ public class JwtTokenProvider {
         } catch (ExpiredJwtException e){
             return e.getClaims();
         }
+    }
+
+    // refreshtoken 생성
+    public String generateRefreshToken(User user) {
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + Long.parseLong(refreshTokenExpireTime));
+
+        return Jwts.builder()
+                .subject(user.getId().toString())
+                .issuedAt(now)
+                .expiration(expireDate)
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    // userId 추출
+    public Long getUserId(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
     }
 }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/controller/KakaoLoginController.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/controller/KakaoLoginController.java
@@ -1,29 +1,42 @@
 package com.sossbar.oauth2.kakao.controller;
 
-import com.sossbar.global.common.code.SuccessCode;
+import com.sossbar.global.common.code.ErrorCode;
+import com.sossbar.global.common.exception.BusinessException;
 import com.sossbar.global.common.template.ApiResTemplate;
 import com.sossbar.global.common.template.SwaggerApiResTemplate;
-import com.sossbar.oauth2.kakao.dto.KakaoToken;
+import com.sossbar.oauth2.kakao.dto.LoginInfoResDto;
 import com.sossbar.oauth2.kakao.service.KakaoLoginService;
+import com.sossbar.oauth2.kakao.service.RefreshTokenService;
+import com.sossbar.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/login")
 @SwaggerApiResTemplate
+@Tag(name = "Login API", description = "로그인 관련 API")
 public class KakaoLoginController {
 
     private final KakaoLoginService kakaoLoginService;
+    private final RefreshTokenService refreshTokenService;
 
     @Operation(summary = "카카오 로그인", description = "카카오 로그인 콜백 api입니다.")
     @GetMapping("/kakao")
-    public ApiResTemplate<KakaoToken> kakaoCallback(@RequestParam String code) {
-        KakaoToken kakaoToken = kakaoLoginService.processLogin(code);
-        return ApiResTemplate.successResponse(SuccessCode.SUCCESS, kakaoToken);
+    public ResponseEntity<ApiResTemplate<LoginInfoResDto>> kakaoCallback(@RequestParam String code) {
+        User user = kakaoLoginService.processLogin(code);
+        return refreshTokenService.loginSuccess(user);
+    }
+
+    @Operation(summary = "리프레시 토큰으로 액세스 토큰 재발급", description = "HttpOnly 쿠키에 있는 refreshToken으로 accessToken을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ApiResTemplate<LoginInfoResDto> getAccessTokenByRefreshToken(@CookieValue(value = "refreshToken", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "리프레시 토큰이 없습니다.");
+        }
+        return refreshTokenService.getAccessTokenByRefreshToken(refreshToken);
     }
 }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/dto/LoginInfoResDto.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/dto/LoginInfoResDto.java
@@ -1,0 +1,7 @@
+    package com.sossbar.oauth2.kakao.dto;
+
+    public record LoginInfoResDto(
+            String accessToken,
+            Long userId
+    ) {
+    }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/KakaoLoginService.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/KakaoLoginService.java
@@ -89,7 +89,7 @@ public class KakaoLoginService {
     }
 
     // 전체 프로세스
-    public KakaoToken processLogin(String code) {
+    public User processLogin(String code) {
         String accessToken = getKakaoAccessToken(code);
         KakaoUserInfo kakaoUserInfo = getUserInfoFromKakao(accessToken);
 
@@ -114,8 +114,6 @@ public class KakaoLoginService {
                         .build())
         );
 
-        String jwt = jwtTokenProvider.generateToken(user);
-
-        return new KakaoToken(jwt);
+        return user;
     }
 }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/RefreshTokenService.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/RefreshTokenService.java
@@ -1,0 +1,95 @@
+package com.sossbar.oauth2.kakao.service;
+
+import com.sossbar.global.common.code.ErrorCode;
+import com.sossbar.global.common.code.SuccessCode;
+import com.sossbar.global.common.exception.BusinessException;
+import com.sossbar.global.common.template.ApiResTemplate;
+import com.sossbar.oauth2.jwt.JwtTokenProvider;
+import com.sossbar.oauth2.kakao.dto.LoginInfoResDto;
+import com.sossbar.user.entity.User;
+import com.sossbar.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Value("${cookie.secure}")
+    private boolean cookieSecure;
+
+    @Value("${cookie.sameSite}")
+    private String cookieSameSite;
+
+    // refreshToken 저장
+    public ResponseEntity<ApiResTemplate<LoginInfoResDto>> loginSuccess(User user) {
+
+        String accessToken = jwtTokenProvider.generateToken(user);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user);
+
+        // DB 저장
+        user.saveRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        // HttpOnly 쿠키로 refreshToken 전달
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(Long.parseLong(jwtTokenProvider.getRefreshTokenExpireTime()) / 1000)
+                .sameSite(cookieSameSite)
+                .build();
+
+        System.out.println("cookieSecure = " + cookieSecure);
+        System.out.println("cookieSameSite = " + cookieSameSite);
+
+        LoginInfoResDto loginInfoResDto = new LoginInfoResDto(accessToken, user.getId());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(ApiResTemplate.successResponse(SuccessCode.SUCCESS, loginInfoResDto));
+    }
+
+    // accessToken 재발급
+    public ApiResTemplate<LoginInfoResDto> getAccessTokenByRefreshToken(String refreshToken) {
+
+        // 토큰 유효성 검사
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.JWT_EXPIRED,
+                    "리프레시 토큰이 만료되었습니다.");
+        }
+
+        // userId 추출 및 엔티티 조회
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.USER_NOT_FOUND_EXCEPTION,
+                        ErrorCode.USER_NOT_FOUND_EXCEPTION.getMessage()
+                ));
+
+        // DB에 저장된 refreshToken과 비교
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN,
+                    ErrorCode.INVALID_REFRESH_TOKEN.getMessage());
+        }
+
+        // 새로운 accessToken 발급
+        String newAccessToken = jwtTokenProvider.generateToken(user);
+
+        LoginInfoResDto loginInfoResDto = new LoginInfoResDto(
+                newAccessToken
+                , user.getId());
+
+        return ApiResTemplate.successResponse(SuccessCode.SUCCESS, loginInfoResDto);
+    }
+}

--- a/SossBar/src/main/java/com/sossbar/user/entity/User.java
+++ b/SossBar/src/main/java/com/sossbar/user/entity/User.java
@@ -27,15 +27,17 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private UserType userType;
+    private String refreshToken;
 
     @Builder
-    public User(String username, String nickname, String email, String bio, String profileImageUrl, UserType userType) {
+    public User(String username, String nickname, String email, String bio, String profileImageUrl, UserType userType, String refreshToken) {
         this.username = username;
         this.nickname = nickname;
         this.email = email;
         this.bio = bio;
         this.profileImageUrl = profileImageUrl;
         this.userType = userType;
+        this.refreshToken = refreshToken;
     }
 
     public void onboarding(UserOnboardingReqDto userInfoSaveReqDto, String profileImageUrl) {
@@ -49,4 +51,9 @@ public class User extends BaseTimeEntity {
         this.bio = userInfoUpdateReqDto.bio();
         this.profileImageUrl = profileImageUrl;
     }
+
+    public void saveRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/SossBar/src/main/resources/application.yml
+++ b/SossBar/src/main/resources/application.yml
@@ -37,6 +37,14 @@ jwt:
   secret: ${JWT_SECRET}
   expire-time: ${JWT_EXPIRE_TIME}
 
+refresh-token:
+  expire:
+    time: ${REFRESH_TOKEN_EXPIRE_TIME}
+
+cookie:
+  secure: ${COOKIE_SECURE}
+  sameSite: ${COOKIE_SAMESITE}
+
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}


### PR DESCRIPTION
## 💻 관련 이슈
> 관련된 이슈 번호를 적어주세요.

- #14 

## ✨ 작업 내용
> 이번 PR에서 작업한 내용을 간단하게 적어주세요.

- 로그인 성공시 HttpOnly 쿠키에 RefreshToken 저장 
- 해당 api 요청시 자동으로 쿠키에 있는 리프레시 토큰과 함께 요청하여 새로운 accessToken 발급
- 로그인 성공시 응답에 userId 추가


## 📄 상세 내용
> 작업의 상세 설명, 고려한 부분, 코드 구조 등에 대해 설명해 주세요.

- reissue api 사용시 accessToken 넣은 상태로도 요청 가능
- 다른 api에서 만료된 jwt 응답 401 에러가 나올 경우 reissue api 사용
- cors 관련 설정은 추후 배포시 삭제 바랍니다 !

## 📷 스크린샷
> 관련된 스크린샷이 있다면 첨부해 주세요.


<img width="380" height="275" alt="image" src="https://github.com/user-attachments/assets/d89791d0-3fb3-444d-8cf5-e9263047e7a2" />



## ✅ 체크리스트
> PR을 보내기 전에 아래 항목들을 확인해 주세요.

- [x] 코드 컨벤션 준수
- [x] 빌드 성공
- [x] 로직 자체 테스트 완료
- [x] 불필요한 파일/코드 제거(개행 정리)
- [x] 이슈 번호 연결 확인 (마지막 커밋 4번으로 잘못 올렸습니다 .. ㅎ)
- [x] EOL(End Of Line) 확인 

## ❕리뷰 요구 사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.

- 키 값 노션에 붙여놨습니다 !
- 잘 되는지 확인 한 번 부탁드려요 ~~
