### PR TITLE
[Refactor/#50] - 프로젝트 생성시 startDate endDate 삭제

### DIFF
--- a/SossBar/src/main/java/com/sossbar/projects/dto/request/ProjectCreateRequest.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/request/ProjectCreateRequest.java
@@ -21,13 +21,5 @@ public class ProjectCreateRequest {
     @Schema(description = "주최사", example = "멋쟁이사자처럼", requiredMode = Schema.RequiredMode.REQUIRED)
     private String host;
 
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Schema(description = "프로젝트 시작 날짜", example = "2025-01-01T00:00:00")
-    private LocalDateTime startDate;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Schema(description = "프로젝트 종료 날짜", example = "2025-12-31T23:59:59")
-    private LocalDateTime endDate;
-
     // 이미지는 MultipartFile로 별도 수신 (Controller의 @RequestPart("image") 참고)
 }

--- a/SossBar/src/main/java/com/sossbar/projects/dto/request/ProjectUpdateRequest.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/request/ProjectUpdateRequest.java
@@ -18,13 +18,5 @@ public class ProjectUpdateRequest {
     @Schema(description = "주최사", example = "멋쟁이사자처럼")
     private String host;
 
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Schema(description = "프로젝트 시작 날짜", example = "2025-01-01T00:00:00")
-    private LocalDateTime startDate;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Schema(description = "프로젝트 종료 날짜", example = "2025-12-31T23:59:59")
-    private LocalDateTime endDate;
-
     // 이미지는 MultipartFile로 별도 수신 (Controller의 @RequestPart("image") 참고)
 }

--- a/SossBar/src/main/java/com/sossbar/projects/dto/response/MyProjectResponse.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/response/MyProjectResponse.java
@@ -16,6 +16,8 @@ public class MyProjectResponse {
     private Long projectId;
     private String projectName;
     private String host;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startDate;
     private String projectLink;
     private String projectImage;

--- a/SossBar/src/main/java/com/sossbar/projects/dto/response/MyProjectResponse.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/response/MyProjectResponse.java
@@ -16,13 +16,7 @@ public class MyProjectResponse {
     private Long projectId;
     private String projectName;
     private String host;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startDate;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime endDate;
-
     private String projectLink;
     private String projectImage;
     private ProjectStatus projectStatus;

--- a/SossBar/src/main/java/com/sossbar/projects/dto/response/ProjectResponse.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/response/ProjectResponse.java
@@ -15,6 +15,8 @@ public class ProjectResponse {
     private Long projectId;
     private String projectName;
     private String host;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startDate;
     private String projectLink;
     private String projectImage;

--- a/SossBar/src/main/java/com/sossbar/projects/dto/response/ProjectResponse.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/response/ProjectResponse.java
@@ -15,11 +15,7 @@ public class ProjectResponse {
     private Long projectId;
     private String projectName;
     private String host;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startDate;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime endDate;
     private String projectLink;
     private String projectImage;
     private ProjectStatus projectStatus;

--- a/SossBar/src/main/java/com/sossbar/projects/dto/response/PublicProjectResponse.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/response/PublicProjectResponse.java
@@ -13,12 +13,6 @@ public class PublicProjectResponse {
     private Long projectId;
     private String projectName;
     private String host;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startDate;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime endDate;
-
     private String projectImage;
 }

--- a/SossBar/src/main/java/com/sossbar/projects/dto/response/PublicProjectResponse.java
+++ b/SossBar/src/main/java/com/sossbar/projects/dto/response/PublicProjectResponse.java
@@ -13,6 +13,8 @@ public class PublicProjectResponse {
     private Long projectId;
     private String projectName;
     private String host;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startDate;
     private String projectImage;
 }

--- a/SossBar/src/main/java/com/sossbar/projects/entity/Project.java
+++ b/SossBar/src/main/java/com/sossbar/projects/entity/Project.java
@@ -32,22 +32,14 @@ public class Project extends BaseTimeEntity {
     @Column(name = "project_image")
     private String projectImage;         // 이미지 (S3 url)
 
-    @Column(name = "start_date")
-    private LocalDateTime startDate;     // 프로젝트 시작 날짜
-
-    @Column(name = "end_date")
-    private LocalDateTime endDate;       // 프로젝트 종료 날짜
-
     @Enumerated(EnumType.STRING)
     @Column(name = "project_status", nullable = false)
     private ProjectStatus projectStatus; // 프로젝트 진행 상황
 
     // 프로젝트 수정 메서드
-    public void update(String projectName, String host, LocalDateTime startDate, LocalDateTime endDate, String projectImage) {
+    public void update(String projectName, String host, String projectImage) {
         if (projectName != null) this.projectName = projectName;
         if (host != null) this.host = host;
-        if (startDate != null) this.startDate = startDate;
-        if (endDate != null) this.endDate = endDate;
         if (projectImage != null) this.projectImage = projectImage;
     }
 

--- a/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
+++ b/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
@@ -52,8 +52,6 @@ public class ProjectService {
         Project project = Project.builder()
                 .projectName(request.getProjectName())
                 .host(request.getHost())
-                .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
                 .projectLink(projectLink)
                 .projectImage(imageUrl)
                 .projectStatus(ProjectStatus.IN_PROGRESS)
@@ -140,8 +138,7 @@ public class ProjectService {
     @Transactional
     public ProjectResponse updateProject(Long projectId, ProjectUpdateRequest request, String newImageUrl) {
         Project project = findProjectById(projectId);
-        project.update(request.getProjectName(), request.getHost(),
-                request.getStartDate(), request.getEndDate(), newImageUrl);
+        project.update(request.getProjectName(), request.getHost(), newImageUrl);
         List<ProjectMember> members = projectMemberRepository.findAllByProject(project);
         return toResponse(project, members);
     }
@@ -175,8 +172,7 @@ public class ProjectService {
                 .projectId(project.getProjectId())
                 .projectName(project.getProjectName())
                 .host(project.getHost())
-                .startDate(project.getStartDate())
-                .endDate(project.getEndDate())
+                .startDate(project.getCreatedAt())
                 .projectLink(project.getProjectLink())
                 .projectImage(project.getProjectImage())
                 .projectStatus(project.getProjectStatus())
@@ -194,8 +190,7 @@ public class ProjectService {
                 .projectId(project.getProjectId())
                 .projectName(project.getProjectName())
                 .host(project.getHost())
-                .startDate(project.getStartDate())
-                .endDate(project.getEndDate())
+                .startDate(project.getCreatedAt())
                 .projectLink(project.getProjectLink())
                 .projectImage(project.getProjectImage())
                 .projectStatus(project.getProjectStatus())
@@ -211,8 +206,7 @@ public class ProjectService {
                 .projectId(project.getProjectId())
                 .projectName(project.getProjectName())
                 .host(project.getHost())
-                .startDate(project.getStartDate())
-                .endDate(project.getEndDate())
+                .startDate(project.getCreatedAt())
                 .projectImage(project.getProjectImage())
                 .build();
     }


### PR DESCRIPTION
## 💻 관련 이슈
> 관련된 이슈 번호를 적어주세요.

- #50 

## ✨ 작업 내용
> 이번 PR에서 작업한 내용을 간단하게 적어주세요.

- 프로젝트 생성시 startdate, enddate 삭제 및 응답에는 startdate 유지


## 📄 상세 내용
> 작업의 상세 설명, 고려한 부분, 코드 구조 등에 대해 설명해 주세요.

- createdAt를 startDate로 매핑하여 프론트에서 필드 이름을 수정하지 않도록 매핑
-

## 📷 스크린샷
> 관련된 스크린샷이 있다면 첨부해 주세요.

- 기존 응답
<img width="985" height="800" alt="image" src="https://github.com/user-attachments/assets/e3bb3000-6c15-4cb5-831a-36b56132cd60" />

- 수정 후 응답
<img width="828" height="712" alt="image" src="https://github.com/user-attachments/assets/368fb826-55b7-4210-8ab6-f41799b0bc60" />


## ✅ 체크리스트
> PR을 보내기 전에 아래 항목들을 확인해 주세요.

- [x] 코드 컨벤션 준수
- [x] 빌드 성공
- [x] 로직 자체 테스트 완료
- [x] 불필요한 파일/코드 제거(개행 정리)
- [x] 이슈 번호 연결 확인
- [x] EOL(End Of Line) 확인 

## ❕리뷰 요구 사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.

- startDate로 응답 잘 보이는지, 프로젝트 생성과 수정 api에서 기간 입력 받는 부분 사라졌는지 확인 부탁드립니다~! 
