### PR TITLE
[Feat/#54] - accessToken HttpOnly Cookie로 변경

### DIFF
--- a/SossBar/src/main/java/com/sossbar/oauth2/jwt/JwtAuthorizationFilter.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/jwt/JwtAuthorizationFilter.java
@@ -6,6 +6,7 @@ import com.sossbar.global.common.exception.BusinessException;
 import com.sossbar.global.common.template.ApiResTemplate;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -64,12 +65,19 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 
-    // 요청에서 토큰 추출 메소드
+    // 요청에서 토큰 추출 메소드 -> 쿠키 추출로 변경
     private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+        // 쿠키 추출
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
         }
+
         return null;
     }
 }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/controller/KakaoLoginController.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/controller/KakaoLoginController.java
@@ -34,7 +34,7 @@ public class KakaoLoginController {
 
     @Operation(summary = "리프레시 토큰으로 액세스 토큰 재발급", description = "HttpOnly 쿠키에 있는 refreshToken으로 accessToken을 재발급합니다.")
     @PostMapping("/reissue")
-    public ApiResTemplate<LoginInfoResDto> getAccessTokenByRefreshToken(@CookieValue(value = "refreshToken", required = false) String refreshToken) {
+    public ResponseEntity<ApiResTemplate<LoginInfoResDto>> getAccessTokenByRefreshToken(@CookieValue(value = "refreshToken", required = false) String refreshToken) {
         if (refreshToken == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "리프레시 토큰이 없습니다.");
         }
@@ -42,7 +42,7 @@ public class KakaoLoginController {
     }
 
     @PostMapping("/test-account")
-    public ApiResTemplate<LoginInfoResDto> testLogin() {
-        return ApiResTemplate.successResponse(SuccessCode.SUCCESS, kakaoLoginService.testLogin());
+    public ResponseEntity<ApiResTemplate<LoginInfoResDto>> testLogin() {
+        return kakaoLoginService.testLogin();
     }
 }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/dto/LoginInfoResDto.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/dto/LoginInfoResDto.java
@@ -1,7 +1,6 @@
     package com.sossbar.oauth2.kakao.dto;
 
     public record LoginInfoResDto(
-            String accessToken,
             Long userId
     ) {
     }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/KakaoLoginService.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/KakaoLoginService.java
@@ -3,7 +3,7 @@ package com.sossbar.oauth2.kakao.service;
 import com.google.gson.Gson;
 import com.sossbar.global.common.code.ErrorCode;
 import com.sossbar.global.common.exception.BusinessException;
-import com.sossbar.oauth2.jwt.JwtTokenProvider;
+import com.sossbar.global.common.template.ApiResTemplate;
 import com.sossbar.oauth2.kakao.dto.KakaoToken;
 import com.sossbar.oauth2.kakao.dto.KakaoUserInfo;
 import com.sossbar.oauth2.kakao.dto.LoginInfoResDto;
@@ -29,7 +29,7 @@ public class KakaoLoginService {
     private String KAKAO_REDIRECT_URI;
 
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
 
@@ -118,16 +118,11 @@ public class KakaoLoginService {
     }
 
     // 테스트 계정 accessToken 발급
-    public LoginInfoResDto testLogin() {
+    public ResponseEntity<ApiResTemplate<LoginInfoResDto>> testLogin() {
         User testUser = userRepository.findByEmail("test@sossbar.com")
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND_EXCEPTION
                         , ErrorCode.USER_NOT_FOUND_EXCEPTION.getMessage()));
 
-        String accessToken = jwtTokenProvider.generateToken(testUser);
-
-        return new LoginInfoResDto(
-                accessToken,
-                testUser.getId()
-        );
+        return refreshTokenService.loginSuccess(testUser);
     }
 }

--- a/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/RefreshTokenService.java
+++ b/SossBar/src/main/java/com/sossbar/oauth2/kakao/service/RefreshTokenService.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -40,6 +42,15 @@ public class RefreshTokenService {
         user.saveRefreshToken(refreshToken);
         userRepository.save(user);
 
+        // HttpOnly 쿠키로 accessToken 전달
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", accessToken)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(Duration.ofDays(1))
+                .sameSite(cookieSameSite)
+                .build();
+
         // HttpOnly 쿠키로 refreshToken 전달
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
@@ -52,15 +63,20 @@ public class RefreshTokenService {
         System.out.println("cookieSecure = " + cookieSecure);
         System.out.println("cookieSameSite = " + cookieSameSite);
 
-        LoginInfoResDto loginInfoResDto = new LoginInfoResDto(accessToken, user.getId());
+        LoginInfoResDto loginInfoResDto = new LoginInfoResDto(user.getId());
+
+        // 헤더에 쿠키 세팅
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .headers(headers)
                 .body(ApiResTemplate.successResponse(SuccessCode.SUCCESS, loginInfoResDto));
     }
 
     // accessToken 재발급
-    public ApiResTemplate<LoginInfoResDto> getAccessTokenByRefreshToken(String refreshToken) {
+    public ResponseEntity<ApiResTemplate<LoginInfoResDto>> getAccessTokenByRefreshToken(String refreshToken) {
 
         // 토큰 유효성 검사
         if (!jwtTokenProvider.validateToken(refreshToken)) {
@@ -86,10 +102,19 @@ public class RefreshTokenService {
         // 새로운 accessToken 발급
         String newAccessToken = jwtTokenProvider.generateToken(user);
 
-        LoginInfoResDto loginInfoResDto = new LoginInfoResDto(
-                newAccessToken
-                , user.getId());
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", newAccessToken)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(Duration.ofDays(1))
+                .sameSite(cookieSameSite)
+                .build();
 
-        return ApiResTemplate.successResponse(SuccessCode.SUCCESS, loginInfoResDto);
+        LoginInfoResDto loginInfoResDto = new LoginInfoResDto(user.getId());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .body(ApiResTemplate.successResponse(SuccessCode.SUCCESS, loginInfoResDto));
+
     }
 }


### PR DESCRIPTION
## 💻 관련 이슈
> 관련된 이슈 번호를 적어주세요.

- #54 

## ✨ 작업 내용
> 이번 PR에서 작업한 내용을 간단하게 적어주세요.

- accessToken 쿠키로 변경


## 📄 상세 내용
> 작업의 상세 설명, 고려한 부분, 코드 구조 등에 대해 설명해 주세요.

- 헤더에 직접 토큰을 넣는 방식이 아닌 쿠키에 있는 토큰이 자동 요청되도록 수정
- 기존 jwt 만료 응답을 사용하여 프론트에서 리프레시 토큰 호출 로직 변경이 없도록 함
- 쿠키의 만료 시간을 1일로 설정, jwt 만료시 액세스 토큰을 재발급 받아도 재생성이 아닌 덮어씌우는 로직


## 📷 스크린샷
> 관련된 스크린샷이 있다면 첨부해 주세요.

- 로그인 성공시 응답 변경
<img width="2558" height="995" alt="image" src="https://github.com/user-attachments/assets/0dceefe0-f5de-424c-972c-e0c164d110a7" />


- 만료시 
<img width="2529" height="1231" alt="image" src="https://github.com/user-attachments/assets/32e4403a-b055-439d-9b4e-b5b44fdd5601" />

- 재발급 후
<img width="2551" height="1240" alt="image" src="https://github.com/user-attachments/assets/06e53a00-b737-41a1-842b-90ae9ace8da3" />



## ✅ 체크리스트
> PR을 보내기 전에 아래 항목들을 확인해 주세요.

- [x] 코드 컨벤션 준수
- [x] 빌드 성공
- [x] 로직 자체 테스트 완료
- [x] 불필요한 파일/코드 제거(개행 정리)
- [x] 이슈 번호 연결 확인
- [x] EOL(End Of Line) 확인 

## ❕리뷰 요구 사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.

- 로그인 성공시 쿠키에 잘 들어가는지, jwt 만료 후 재발급 받고 다른 api 호출 가능한지 봐주시면 감사하겠습니다~!
