### PR TITLE
[Fix/#60] - 프로젝트 상태 필터링 후 조회 가능하도록 수정

### DIFF
--- a/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
+++ b/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
@@ -81,6 +81,8 @@ public class ProjectService {
         List<ProjectMember> myMemberships = projectMemberRepository.findAllByUser(user);
         List<Project> myProjects = myMemberships.stream()
                 .map(ProjectMember::getProject)
+                .filter(p -> p.getProjectStatus() == ProjectStatus.COMPLETED
+                || p.getProjectStatus() == ProjectStatus.ARCHIVED)
                 .toList();
 
         List<ProjectMember> allMembers = projectMemberRepository.findAllByProjects(myProjects);
@@ -96,6 +98,8 @@ public class ProjectService {
 
         // 3. 각 Project의 전체 멤버 조회 후 나를 제외하고 MyProjectResponse로 변환
         return myMemberships.stream()
+                .filter(pm -> pm.getProject().getProjectStatus() == ProjectStatus.COMPLETED
+                        || pm.getProject().getProjectStatus() == ProjectStatus.ARCHIVED) // 팀원 확정된 프로젝트 + 리뷰 작성 완료된 프로젝트만 필터링
                 .map(pm -> {
                     List<ProjectMember> allProjectMembers = membersByProject
                             .getOrDefault(pm.getProject().getProjectId(), List.of());
@@ -120,11 +124,11 @@ public class ProjectService {
         List<ProjectMember> memberships = projectMemberRepository.findAllByUser(user);
 
         // 3. 각 Project의 전체 멤버 조회 후 PublicProjectResponse로 변환
-        // TODO: 후기 작성이 완료된 프로젝트만 외부에 노출할 경우 아래 filter 활성화
-        // 후기 작성 완료 상태 = ProjectStatus.ARCHIVED
-        // .filter(pm -> pm.getProject().getProjectStatus() == ProjectStatus.ARCHIVED)
-
         return memberships.stream()
+                .filter(pm -> {
+                    ProjectStatus status = pm.getProject().getProjectStatus();
+                    return status == ProjectStatus.COMPLETED || status == ProjectStatus.ARCHIVED;
+                }) // 팀원 확정된 프로젝트 + 리뷰 작성 완료된 프로젝트만 필터링
                 .map(pm -> toPublicResponse(pm.getProject()))
                 .toList();
     }

--- a/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
+++ b/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
@@ -102,8 +102,6 @@ public class ProjectService {
 
         // 3. 각 Project의 전체 멤버 조회 후 나를 제외하고 MyProjectResponse로 변환
         return myMemberships.stream()
-                .filter(pm -> pm.getProject().getProjectStatus() == ProjectStatus.COMPLETED
-                        || pm.getProject().getProjectStatus() == ProjectStatus.ARCHIVED) // 팀원 확정된 프로젝트 + 리뷰 작성 완료된 프로젝트만 필터링
                 .map(pm -> {
                     List<ProjectMember> allProjectMembers = membersByProject
                             .getOrDefault(pm.getProject().getProjectId(), List.of());

--- a/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
+++ b/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
@@ -79,10 +79,14 @@ public class ProjectService {
 
         // 2. 내가 속한 ProjectMember 목록 조회 (fetch join으로 project 포함 → N+1 방지)
         List<ProjectMember> myMemberships = projectMemberRepository.findAllByUser(user);
-        List<Project> myProjects = myMemberships.stream()
+
+        List<ProjectMember> filteredMemberships = myMemberships.stream()
+                .filter(pm -> pm.getProject().getProjectStatus() == ProjectStatus.COMPLETED
+                        || pm.getProject().getProjectStatus() == ProjectStatus.ARCHIVED) // 팀원 확정된 프로젝트 + 리뷰 작성 완료된 프로젝트만 필터링
+                .toList();
+
+        List<Project> myProjects = filteredMemberships.stream()
                 .map(ProjectMember::getProject)
-                .filter(p -> p.getProjectStatus() == ProjectStatus.COMPLETED
-                || p.getProjectStatus() == ProjectStatus.ARCHIVED)
                 .toList();
 
         List<ProjectMember> allMembers = projectMemberRepository.findAllByProjects(myProjects);
@@ -125,10 +129,8 @@ public class ProjectService {
 
         // 3. 각 Project의 전체 멤버 조회 후 PublicProjectResponse로 변환
         return memberships.stream()
-                .filter(pm -> {
-                    ProjectStatus status = pm.getProject().getProjectStatus();
-                    return status == ProjectStatus.COMPLETED || status == ProjectStatus.ARCHIVED;
-                }) // 팀원 확정된 프로젝트 + 리뷰 작성 완료된 프로젝트만 필터링
+                .filter(pm -> pm.getProject().getProjectStatus() == ProjectStatus.COMPLETED
+                || pm.getProject().getProjectStatus() == ProjectStatus.ARCHIVED) // 팀원 확정된 프로젝트 + 리뷰 작성 완료된 프로젝트만 필터링
                 .map(pm -> toPublicResponse(pm.getProject()))
                 .toList();
     }

--- a/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
+++ b/SossBar/src/main/java/com/sossbar/projects/service/ProjectService.java
@@ -80,9 +80,9 @@ public class ProjectService {
         // 2. 내가 속한 ProjectMember 목록 조회 (fetch join으로 project 포함 → N+1 방지)
         List<ProjectMember> myMemberships = projectMemberRepository.findAllByUser(user);
 
+        // DELETED 제외
         List<ProjectMember> filteredMemberships = myMemberships.stream()
-                .filter(pm -> pm.getProject().getProjectStatus() == ProjectStatus.COMPLETED
-                        || pm.getProject().getProjectStatus() == ProjectStatus.ARCHIVED) // 팀원 확정된 프로젝트 + 리뷰 작성 완료된 프로젝트만 필터링
+                .filter(pm -> pm.getProject().getProjectStatus() != ProjectStatus.DELETED)
                 .toList();
 
         List<Project> myProjects = filteredMemberships.stream()
@@ -101,7 +101,7 @@ public class ProjectService {
                 ));
 
         // 3. 각 Project의 전체 멤버 조회 후 나를 제외하고 MyProjectResponse로 변환
-        return myMemberships.stream()
+        return filteredMemberships.stream()
                 .map(pm -> {
                     List<ProjectMember> allProjectMembers = membersByProject
                             .getOrDefault(pm.getProject().getProjectId(), List.of());


### PR DESCRIPTION
## 💻 관련 이슈
> 관련된 이슈 번호를 적어주세요.

- #60 


## ✨ 작업 내용
> 이번 PR에서 작업한 내용을 간단하게 적어주세요.

- 프로젝트 필터링 가능하도록 수정


## 📄 상세 내용
> 작업의 상세 설명, 고려한 부분, 코드 구조 등에 대해 설명해 주세요.

- project_status = COMPLETED나 project_status = ARCHIVED인 프로젝트만 프로젝트 리스트 조회할 때 뜨도록 수정했습니다


## 📷 스크린샷
> 관련된 스크린샷이 있다면 첨부해 주세요.

- 내 프로젝트 리스트 조회
<img width="418" height="1097" alt="image" src="https://github.com/user-attachments/assets/d3b127aa-58b7-4f72-b9f0-8f7c2f766e0e" />

- 유저 프로젝트 리스트 조회
<img width="617" height="1208" alt="image" src="https://github.com/user-attachments/assets/5b905379-56e9-49f3-9062-20a40a1afb96" />



## ✅ 체크리스트
> PR을 보내기 전에 아래 항목들을 확인해 주세요.

- [x] 코드 컨벤션 준수
- [x] 빌드 성공
- [x] 로직 자체 테스트 완료
- [x] 불필요한 파일/코드 제거(개행 정리)
- [x] 이슈 번호 연결 확인
- [x] EOL(End Of Line) 확인 


## ❕리뷰 요구 사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요.

- project_status = ARCHIVED는 필요가 없어 보이는데, 후에 고도화 때 관련 기능이 추가될 수도 있을 것 같아 일단  남겨두었습니다! IN_PROGRESS인 프로젝트가 뜨지 않으면 요구사항에 부합할 듯합니다. 
- 내 프로젝트 리스트 조회, 유저 프로젝트 리스트 조회 모두 확인 부탁드립니다!! 😄 